### PR TITLE
fix: added mechanism to handle serialization failure gracefully

### DIFF
--- a/src/main/kotlin/io/github/damir/denis/tudor/ktor/server/rabbitmq/delegator/StateRegistry.kt
+++ b/src/main/kotlin/io/github/damir/denis/tudor/ktor/server/rabbitmq/delegator/StateRegistry.kt
@@ -93,8 +93,7 @@ object StateRegistry {
 
         currentRef::class.memberProperties.map {
             val state = states.get()[currentRef.javaClass.name to it.name]
-            val initialized = (state is State.Initialized)
-            val value = if (initialized) state.value else "Uninitialized"
+            val value = if ((state is State.Initialized)) state.value else "Uninitialized"
             logger.get().error("<{}> <{}>, value: <{}>", ref.get()?.javaClass?.simpleName, it.name, value)
         }
     }

--- a/src/test/kotlin/integration/SerializationTests.kt
+++ b/src/test/kotlin/integration/SerializationTests.kt
@@ -1,0 +1,336 @@
+package integration
+
+import io.github.damir.denis.tudor.ktor.server.rabbitmq.RabbitMQ
+import io.github.damir.denis.tudor.ktor.server.rabbitmq.dsl.*
+import io.ktor.server.application.*
+import io.ktor.server.testing.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.RabbitMQContainer
+import org.testcontainers.utility.DockerImageName
+import rabbitmqTest
+import java.lang.Thread.sleep
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+class SerializationTests {
+
+    @Serializable
+    data class Message(
+        var content: String
+    )
+
+    companion object {
+        private val rabbitMQContainer: RabbitMQContainer = RabbitMQContainer(
+            DockerImageName.parse("rabbitmq:management")
+        )
+
+        @BeforeAll
+        @JvmStatic
+        fun setUp() {
+            rabbitMQContainer.start()
+            println("RabbitMQ is running at ${rabbitMQContainer.amqpUrl}")
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            rabbitMQContainer.stop()
+            println("RabbitMQ is stopped")
+        }
+    }
+
+    @Test
+    fun `every message should be able to be serialized as String`() = testApplication {
+        application {
+            install(RabbitMQ) {
+                connectionAttempts = 3
+                attemptDelay = 10
+                uri = rabbitMQContainer.amqpUrl
+                consumerChannelCoroutineSize = 100
+            }
+        }
+
+        application {
+            rabbitmqTest {
+                queueBind {
+                    queue = "demo1-queue"
+                    exchange = "demo1-exchange"
+                    routingKey = "demo1-routing-key"
+                    queueDeclare {
+                        queue = "demo1-queue"
+                    }
+                    exchangeDeclare {
+                        exchange = "demo1-exchange"
+                        type = "direct"
+                    }
+                }
+            }
+
+            rabbitmqTest {
+                repeat(10) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { Message(content = "Hello World, 'Message'!") }
+                    }
+                }
+                repeat(90) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { "Hello World, 'String'!" }
+                    }
+                }
+            }
+
+            val counter1 = AtomicInteger(0)
+
+            rabbitmqTest {
+                basicConsume {
+                    autoAck = true
+                    queue = "demo1-queue"
+                    dispatcher = Dispatchers.IO
+                    deliverCallback<String> { tag, message ->
+                        delay(3)
+                        counter1.incrementAndGet()
+                        log.info("Consume1 : $message")
+                    }
+                }
+            }
+
+            sleep(2_000)
+
+            log.info(counter1.toString())
+
+            assert(counter1.get() == 100)
+        }
+    }
+
+    @Test
+    fun `every message should be able to be serialized as ByteArray`() = testApplication {
+        application {
+            install(RabbitMQ) {
+                connectionAttempts = 3
+                attemptDelay = 10
+                uri = rabbitMQContainer.amqpUrl
+                consumerChannelCoroutineSize = 100
+            }
+        }
+
+        application {
+            rabbitmqTest {
+                queueBind {
+                    queue = "demo1-queue"
+                    exchange = "demo1-exchange"
+                    routingKey = "demo1-routing-key"
+                    queueDeclare {
+                        queue = "demo1-queue"
+                    }
+                    exchangeDeclare {
+                        exchange = "demo1-exchange"
+                        type = "direct"
+                    }
+                }
+            }
+
+            rabbitmqTest {
+                repeat(10) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { Message(content = "Hello World, 'Message'!") }
+                    }
+                }
+                repeat(90) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { "Hello World, 'String'!" }
+                    }
+                }
+            }
+
+            val counter1 = AtomicInteger(0)
+
+            rabbitmqTest {
+                basicConsume {
+                    autoAck = true
+                    queue = "demo1-queue"
+                    dispatcher = Dispatchers.IO
+                    deliverCallback<ByteArray> { tag, message ->
+                        delay(3)
+                        counter1.incrementAndGet()
+                        log.info("Consume1 : ${message.contentToString()}")
+                    }
+                }
+            }
+
+            sleep(2_000)
+
+            log.info(counter1.toString())
+
+            assert(counter1.get() == 100)
+        }
+    }
+
+    @Test
+    fun `when a message cannot be serialized ignore messages`() = testApplication {
+        application {
+            install(RabbitMQ) {
+                connectionAttempts = 3
+                attemptDelay = 10
+                uri = rabbitMQContainer.amqpUrl
+                consumerChannelCoroutineSize = 100
+            }
+        }
+
+        application {
+            rabbitmqTest {
+                queueBind {
+                    queue = "demo1-queue"
+                    exchange = "demo1-exchange"
+                    routingKey = "demo1-routing-key"
+                    queueDeclare {
+                        queue = "demo1-queue"
+                    }
+                    exchangeDeclare {
+                        exchange = "demo1-exchange"
+                        type = "direct"
+                    }
+                }
+            }
+
+            rabbitmqTest {
+                repeat(10) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { Message(content = "Hello World, 'Message'!") }
+                    }
+                }
+                repeat(90) {
+                    basicPublish {
+                        exchange = "demo1-exchange"
+                        routingKey = "demo1-routing-key"
+                        message { "Hello World, 'String'!" }
+                    }
+                }
+            }
+
+            val counter1 = AtomicInteger(0)
+
+            rabbitmqTest {
+                basicConsume {
+                    autoAck = true
+                    queue = "demo1-queue"
+                    dispatcher = Dispatchers.IO
+                    deliverCallback<Message> { tag, message ->
+                        delay(3)
+                        counter1.incrementAndGet()
+                        log.info("Consume1 : $message")
+                    }
+                }
+            }
+
+            sleep(2_000)
+
+            log.info(counter1.toString())
+
+            assert(counter1.get() == 10)
+        }
+    }
+
+    @Test
+    fun `when a message cannot be serialized use callback mechanism that reject the message in a dlq`() = testApplication {
+        application {
+            install(RabbitMQ) {
+                connectionAttempts = 3
+                attemptDelay = 10
+                uri = rabbitMQContainer.amqpUrl
+                consumerChannelCoroutineSize = 100
+            }
+        }
+
+        application {
+            rabbitmqTest {
+                queueBind {
+                    queue = "dlq1"
+                    exchange = "dlx1"
+                    routingKey = "dlq-dlx1"
+                    queueDeclare {
+                        queue = "dlq1"
+                        durable = true
+                    }
+                    exchangeDeclare {
+                        exchange = "dlx1"
+                        type = "direct"
+                    }
+                }
+
+                queueBind {
+                    queue = "test-queue12"
+                    exchange = "test-exchange12"
+                    queueDeclare {
+                        queue = "test-queue12"
+                        arguments = mapOf(
+                            "x-dead-letter-exchange" to "dlx1",
+                            "x-dead-letter-routing-key" to "dlq-dlx1"
+                        )
+                    }
+                    exchangeDeclare {
+                        exchange = "test-exchange12"
+                        type = "fanout"
+                    }
+                }
+            }
+
+            rabbitmqTest {
+                repeat(10) {
+                    basicPublish {
+                        exchange = "test-exchange12"
+                        message { Message(content = "Hello World, 'Message'!") }
+                    }
+                }
+                repeat(90) {
+                    basicPublish {
+                        exchange = "test-exchange12"
+                        message { "Hello World, 'String'!" }
+                    }
+                }
+            }
+
+            val counter1 = AtomicInteger(0)
+
+            rabbitmqTest {
+                basicConsume {
+                    autoAck = false
+                    queue = "test-queue12"
+                    dispatcher = Dispatchers.IO
+                    deliverCallback<Message> { _, _ ->
+                        delay(3)
+                        counter1.incrementAndGet()
+                    }
+                    deliverFailureCallback { tag, _ ->
+                        basicReject {
+                            deliveryTag = tag
+                            requeue = false
+                        }
+                    }
+                }
+            }
+
+            sleep(2_000)
+
+            assert(counter1.get() == 10)
+
+            rabbitmqTest {
+                assertEquals(messageCount { queue = "dlq1" }, 90)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- A new method, `deliverFailureCallback`, has been added to the `basicConsume` builder.
- By default, all messages can be deserialized as `String` or `ByteArray`.
- If deserialization to the specified type fails and `deliverFailureCallback` is invoked, the responsibility for handling the failure falls to the end user. If this callback is not provided, the failed message will be quietly ignored.
- Additionally, a series of tests has been included.