### PR TITLE
fix: using robust connection with Kourier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ out/
 ### VS Code ###
 .vscode/
 
-/.kotlin 
+/.kotlin
+
+### macOS ###
+.DS_Store

--- a/ktor-server-rabbitmq-kourier/src/commonMain/kotlin/io/github/damir/denis/tudor/ktor/server/rabbitmq/connection/KourierConnectionManager.kt
+++ b/ktor-server-rabbitmq-kourier/src/commonMain/kotlin/io/github/damir/denis/tudor/ktor/server/rabbitmq/connection/KourierConnectionManager.kt
@@ -3,7 +3,7 @@ package io.github.damir.denis.tudor.ktor.server.rabbitmq.connection
 import dev.kourier.amqp.AMQPException
 import dev.kourier.amqp.connection.AMQPConfig
 import dev.kourier.amqp.connection.amqpConfig
-import dev.kourier.amqp.connection.createAMQPConnection
+import dev.kourier.amqp.robust.createRobustAMQPConnection
 import io.github.damir.denis.tudor.ktor.server.rabbitmq.model.Connection
 import io.github.damir.denis.tudor.ktor.server.rabbitmq.model.KourierConnection
 import kotlinx.coroutines.*
@@ -100,7 +100,7 @@ open class KourierConnectionManager(
 
             val connection = connectionCache.getOrPut(id) {
                 logger.debug("Creating new connection with id: <$id>.")
-                createAMQPConnection(
+                createRobustAMQPConnection(
                     coroutineScope,
                     amqpConfig.copy(server = amqpConfig.server.copy(connectionName = id))
                 ).let(::KourierConnection)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
 
             // AMQP clients
             library("amqp-java", "com.rabbitmq:amqp-client:5.24.0")
-            library("amqp-kourier", "dev.kourier:amqp-client-robust:0.2.4")
+            library("amqp-kourier", "dev.kourier:amqp-client-robust:0.2.8")
 
             // Tests
             library("tests-mockk", "io.mockk:mockk:1.13.12")


### PR DESCRIPTION
This includes fixes from Kourier.

Also, if we are okay with the actual implementation and test, maybe we should consider merging `33-going-kotlin-multiplatform-support-native-linuxmacoswindows` into main!