### PR TITLE
Update amqp-kourier library version to 0.4.3

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
 
             // AMQP clients
             library("amqp-java", "com.rabbitmq:amqp-client:5.24.0")
-            library("amqp-kourier", "dev.kourier:amqp-client-robust:0.3.2")
+            library("amqp-kourier", "dev.kourier:amqp-client-robust:0.4.3")
 
             // Tests
             library("tests-mockk", "io.mockk:mockk:1.13.12")


### PR DESCRIPTION
We've done a lot of fixes and improvements in Kourier in the past updates. So I guess it's worth updating it to its latest version.